### PR TITLE
adding status update cloud event

### DIFF
--- a/eventhandlers.go
+++ b/eventhandlers.go
@@ -237,7 +237,16 @@ func HandleTestTriggeredEvent(myKeptn *keptnv2.Keptn, incomingEvent cloudevents.
 		log.Println("No locust.conf.yaml file provided. Continuing with default settings!")
 	}
 
-	log.Printf("TestStrategy=%s -> testFile=%s, serviceUrl=%s\n", data.Test.TestStrategy, locustFilename, serviceURL.String())
+	msg := fmt.Sprintf("TestStrategy=%s -> testFile=%s, serviceUrl=%s\n", data.Test.TestStrategy, locustFilename, serviceURL.String())
+	fmt.Printf(msg)
+
+	_, err = myKeptn.SendTaskStatusChangedEvent(&keptnv2.EventData{
+		Message: msg,
+	}, ServiceName)
+
+	if err != nil {
+		log.Printf("Could not send status changed event: %s", err.Error())
+	}
 
 	var locustResouceFilenameLocal = ""
 	if locustFilename != "" {


### PR DESCRIPTION
Sends an event once the service determined which test file will be executed, as can be seen in this screenshot:

![image](https://user-images.githubusercontent.com/7677092/118708080-93e7c580-b81b-11eb-95aa-32f7b6be9137.png)



Signed-off-by: jetzlstorfer <juergen.etzlstorfer@dynatrace.com>