### PR TITLE
Change version of helm chart to locust-service version from keptn version

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.8.7
+appVersion: 0.1.5
 description: Helm Chart for the keptn locust-service
 name: locust-service
 type: application
-version: 0.8.7
+version: 0.1.5


### PR DESCRIPTION
Use the version of the locust-service in the helm chart instead of the keptn version. Currently in [deploy/service.yaml](https://github.com/keptn-sandbox/locust-service/blob/main/deploy/service.yaml) the `app.kubernetes.io/version` gets set to `0.1.5`, while for the helm chart the version from `chart.yaml` is used, resulting in `app.kubernetes.io/version: 0.8.7`.

The version is also used in the uniform registration and displayed in the bridge and probably should be the same for each deployment method.